### PR TITLE
feat: full pipeline viewer with sidebar, auto-polling, and target management

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: nix develop --command just bundle
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/dist/index.html
+++ b/dist/index.html
@@ -20,6 +20,15 @@
     .btn { padding: 10px 16px; border: none; border-radius: 6px; background: #2196f3; color: #fff; font-size: 14px; cursor: pointer; }
     .btn:hover { background: #1976d2; }
     .hint { color: #666; font-size: 12px; margin-top: 12px; }
+    .btn-back { padding: 6px 14px; border: 1px solid #333; border-radius: 6px; background: transparent; color: #9e9e9e; font-size: 13px; cursor: pointer; margin-bottom: 16px; }
+    .btn-back:hover { border-color: #666; color: #e0e0e0; }
+    .targets { margin-top: 24px; }
+    .targets h3 { color: #9e9e9e; font-size: 13px; margin-bottom: 8px; }
+    .target { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border: 1px solid #333; border-radius: 6px; margin-bottom: 6px; }
+    .target-label { color: #2196f3; cursor: pointer; font-size: 14px; }
+    .target-label:hover { text-decoration: underline; }
+    .target-remove { color: #666; cursor: pointer; font-size: 12px; padding: 2px 6px; }
+    .target-remove:hover { color: #f44336; }
   </style>
 </head>
 <body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -24,8 +24,11 @@
     .sidebar { width: 200px; flex-shrink: 0; border-right: 1px solid #333; padding-right: 16px; }
     .sidebar-title { color: #666; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; margin-top: 12px; }
     .sidebar-form { display: flex; flex-direction: column; gap: 6px; margin-bottom: 8px; }
+    .sidebar-form-row { display: flex; gap: 6px; }
     .input-sm { padding: 6px 8px; font-size: 12px; }
-    .btn-sm { padding: 6px 10px; font-size: 12px; }
+    .btn-sm { padding: 6px 10px; font-size: 12px; flex: 1; }
+    .btn-add { width: 100%; padding: 4px; border: 1px dashed #444; border-radius: 6px; background: transparent; color: #666; font-size: 16px; cursor: pointer; margin-bottom: 8px; }
+    .btn-add:hover { border-color: #2196f3; color: #2196f3; }
     .tree-owner { color: #9e9e9e; font-size: 12px; font-weight: 600; padding: 6px 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-ref { color: #9e9e9e; font-size: 12px; padding: 3px 8px 3px 16px; border-radius: 4px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -21,7 +21,7 @@
     .btn:hover { background: #1976d2; }
     .hint { color: #666; font-size: 12px; margin-top: 12px; }
     .layout { display: flex; gap: 16px; }
-    .sidebar { width: 200px; flex-shrink: 0; border-right: 1px solid #333; padding-right: 16px; }
+    .sidebar { width: 300px; flex-shrink: 0; border-right: 1px solid #333; padding-right: 16px; }
     .sidebar-title { color: #666; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; margin-top: 12px; }
     .sidebar-form { display: flex; flex-direction: column; gap: 6px; margin-bottom: 8px; }
     .sidebar-form-row { display: flex; gap: 4px; align-items: center; }
@@ -36,6 +36,7 @@
     .tree-remove:hover { color: #f44336; }
     .tree-ref { color: #9e9e9e; font-size: 12px; padding: 3px 8px 3px 16px; border-radius: 4px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-ref:hover { color: #2196f3; background: #16213e; }
+    .tree-ref-title { color: #555; font-size: 11px; }
     .form-tree-owner { font-size: 13px; margin-top: 8px; }
     .form-tree-repo { font-size: 12px; }
     .main { flex: 1; min-width: 0; }
@@ -52,6 +53,7 @@
     .target { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border: 1px solid #333; border-radius: 6px; margin-bottom: 6px; }
     .target-label { color: #2196f3; cursor: pointer; font-size: 14px; }
     .target-label:hover { text-decoration: underline; }
+    .target-title { color: #777; font-size: 12px; font-weight: 400; }
     .target-remove { color: #666; cursor: pointer; font-size: 12px; padding: 2px 6px; }
     .target-remove:hover { color: #f44336; }
   </style>

--- a/dist/index.html
+++ b/dist/index.html
@@ -20,6 +20,12 @@
     .btn { padding: 10px 16px; border: none; border-radius: 6px; background: #2196f3; color: #fff; font-size: 14px; cursor: pointer; }
     .btn:hover { background: #1976d2; }
     .hint { color: #666; font-size: 12px; margin-top: 12px; }
+    .layout { display: flex; gap: 16px; }
+    .sidebar { width: 180px; flex-shrink: 0; border-right: 1px solid #333; padding-right: 16px; }
+    .sidebar-title { color: #666; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+    .sidebar-item { color: #9e9e9e; font-size: 13px; padding: 4px 8px; border-radius: 4px; cursor: pointer; margin-bottom: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .sidebar-item:hover { color: #2196f3; background: #16213e; }
+    .main { flex: 1; min-width: 0; }
     .toolbar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; }
     .btn-back { padding: 6px 14px; border: 1px solid #333; border-radius: 6px; background: transparent; color: #9e9e9e; font-size: 13px; cursor: pointer; }
     .toolbar-timer { display: flex; align-items: center; gap: 6px; color: #666; font-size: 12px; margin-left: auto; font-variant-numeric: tabular-nums; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GHA Live</title>
+  <style>
+    body { font-family: system-ui, sans-serif; background: #1a1a2e; padding: 24px; }
+    .error { color: #f44336; }
+    .job-node { cursor: pointer; }
+    @keyframes pulse { 50% { opacity: 0.6; } }
+    .running { animation: pulse 1.5s ease-in-out infinite; }
+  </style>
 </head>
 <body>
   <div id="app"></div>

--- a/dist/index.html
+++ b/dist/index.html
@@ -20,6 +20,7 @@
     .btn { padding: 10px 16px; border: none; border-radius: 6px; background: #2196f3; color: #fff; font-size: 14px; cursor: pointer; }
     .btn:hover { background: #1976d2; }
     .hint { color: #666; font-size: 12px; margin-top: 12px; }
+    .toolbar { display: flex; gap: 8px; margin-bottom: 16px; }
     .btn-back { padding: 6px 14px; border: 1px solid #333; border-radius: 6px; background: transparent; color: #9e9e9e; font-size: 13px; cursor: pointer; margin-bottom: 16px; }
     .btn-back:hover { border-color: #666; color: #e0e0e0; }
     .targets { margin-top: 24px; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -24,9 +24,10 @@
     .sidebar { width: 200px; flex-shrink: 0; border-right: 1px solid #333; padding-right: 16px; }
     .sidebar-title { color: #666; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; margin-top: 12px; }
     .sidebar-form { display: flex; flex-direction: column; gap: 6px; margin-bottom: 8px; }
-    .sidebar-form-row { display: flex; gap: 6px; }
+    .sidebar-form-row { display: flex; gap: 4px; align-items: center; }
+    .url-input { flex: 1; min-width: 0; }
     .input-sm { padding: 6px 8px; font-size: 12px; }
-    .btn-sm { padding: 6px 10px; font-size: 12px; flex: 1; }
+    .btn-sm { padding: 6px 10px; font-size: 12px; white-space: nowrap; }
     .btn-add { width: 100%; padding: 4px; border: 1px dashed #444; border-radius: 6px; background: transparent; color: #666; font-size: 16px; cursor: pointer; margin-bottom: 8px; }
     .btn-add:hover { border-color: #2196f3; color: #2196f3; }
     .tree-owner { color: #9e9e9e; font-size: 12px; font-weight: 600; padding: 6px 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -39,6 +39,7 @@
     .form-tree-owner { font-size: 13px; margin-top: 8px; }
     .form-tree-repo { font-size: 12px; }
     .main { flex: 1; min-width: 0; }
+    .heading { color: #e0e0e0; font-size: 15px; font-weight: 500; margin: 0 0 12px; }
     .toolbar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; }
     .btn-back { padding: 6px 14px; border: 1px solid #333; border-radius: 6px; background: transparent; color: #9e9e9e; font-size: 13px; cursor: pointer; }
     .toolbar-timer { display: flex; align-items: center; gap: 6px; color: #666; font-size: 12px; margin-left: auto; font-variant-numeric: tabular-nums; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -20,8 +20,12 @@
     .btn { padding: 10px 16px; border: none; border-radius: 6px; background: #2196f3; color: #fff; font-size: 14px; cursor: pointer; }
     .btn:hover { background: #1976d2; }
     .hint { color: #666; font-size: 12px; margin-top: 12px; }
-    .toolbar { display: flex; gap: 8px; margin-bottom: 16px; }
-    .btn-back { padding: 6px 14px; border: 1px solid #333; border-radius: 6px; background: transparent; color: #9e9e9e; font-size: 13px; cursor: pointer; margin-bottom: 16px; }
+    .toolbar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; }
+    .btn-back { padding: 6px 14px; border: 1px solid #333; border-radius: 6px; background: transparent; color: #9e9e9e; font-size: 13px; cursor: pointer; }
+    .toolbar-timer { display: flex; align-items: center; gap: 6px; color: #666; font-size: 12px; margin-left: auto; font-variant-numeric: tabular-nums; }
+    .btn-small { padding: 2px 8px; border: 1px solid #333; border-radius: 4px; background: transparent; color: #9e9e9e; font-size: 12px; cursor: pointer; }
+    .btn-small:hover { border-color: #666; color: #e0e0e0; }
+    .btn-small:disabled { opacity: 0.3; cursor: default; }
     .btn-back:hover { border-color: #666; color: #e0e0e0; }
     .targets { margin-top: 24px; }
     .targets h3 { color: #9e9e9e; font-size: 13px; margin-bottom: 8px; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -31,7 +31,9 @@
     .btn-add { width: 100%; padding: 4px; border: 1px dashed #444; border-radius: 6px; background: transparent; color: #666; font-size: 16px; cursor: pointer; margin-bottom: 8px; }
     .btn-add:hover { border-color: #2196f3; color: #2196f3; }
     .tree-owner { color: #9e9e9e; font-size: 12px; font-weight: 600; padding: 6px 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; justify-content: space-between; }
+    .tree-remove { color: #555; cursor: pointer; font-size: 10px; padding: 0 4px; flex-shrink: 0; }
+    .tree-remove:hover { color: #f44336; }
     .tree-ref { color: #9e9e9e; font-size: 12px; padding: 3px 8px 3px 16px; border-radius: 4px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-ref:hover { color: #2196f3; background: #16213e; }
     .form-tree-owner { font-size: 13px; margin-top: 8px; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -23,8 +23,12 @@
     .layout { display: flex; gap: 16px; }
     .sidebar { width: 180px; flex-shrink: 0; border-right: 1px solid #333; padding-right: 16px; }
     .sidebar-title { color: #666; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
-    .sidebar-item { color: #9e9e9e; font-size: 13px; padding: 4px 8px; border-radius: 4px; cursor: pointer; margin-bottom: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .sidebar-item:hover { color: #2196f3; background: #16213e; }
+    .tree-owner { color: #9e9e9e; font-size: 12px; font-weight: 600; padding: 6px 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tree-ref { color: #9e9e9e; font-size: 12px; padding: 3px 8px 3px 16px; border-radius: 4px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tree-ref:hover { color: #2196f3; background: #16213e; }
+    .form-tree-owner { font-size: 13px; margin-top: 8px; }
+    .form-tree-repo { font-size: 12px; }
     .main { flex: 1; min-width: 0; }
     .toolbar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; }
     .btn-back { padding: 6px 14px; border: 1px solid #333; border-radius: 6px; background: transparent; color: #9e9e9e; font-size: 13px; cursor: pointer; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -30,6 +30,7 @@
     .btn-sm { padding: 6px 10px; font-size: 12px; white-space: nowrap; }
     .btn-add { width: 100%; padding: 4px; border: 1px dashed #444; border-radius: 6px; background: transparent; color: #666; font-size: 16px; cursor: pointer; margin-bottom: 8px; }
     .btn-add:hover { border-color: #2196f3; color: #2196f3; }
+    .btn-add-token { font-size: 14px; padding: 2px; }
     .tree-owner { color: #9e9e9e; font-size: 12px; font-weight: 600; padding: 6px 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; justify-content: space-between; }
     .tree-remove { color: #555; cursor: pointer; font-size: 10px; padding: 0 4px; flex-shrink: 0; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -28,8 +28,8 @@
     .url-input { flex: 1; min-width: 0; }
     .input-sm { padding: 6px 8px; font-size: 12px; }
     .btn-sm { padding: 6px 10px; font-size: 12px; white-space: nowrap; }
-    .btn-add { width: 100%; padding: 4px; border: 1px dashed #444; border-radius: 6px; background: transparent; color: #666; font-size: 16px; cursor: pointer; margin-bottom: 8px; }
-    .btn-add:hover { border-color: #2196f3; color: #2196f3; }
+    .btn-add { width: 100%; padding: 4px; border: 1px dashed #252542; border-radius: 6px; background: #252542; color: #666; font-size: 16px; cursor: pointer; margin-bottom: 8px; }
+    .btn-add:hover { background: #2a2a50; border-color: #2a2a50; color: #9e9e9e; }
     .btn-add-token { font-size: 14px; padding: 2px; }
     .tree-owner { color: #9e9e9e; font-size: 12px; font-weight: 600; padding: 6px 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; justify-content: space-between; }
@@ -42,13 +42,15 @@
     .form-tree-repo { font-size: 12px; }
     .main { flex: 1; min-width: 0; }
     .heading { color: #e0e0e0; font-size: 15px; font-weight: 500; margin: 0 0 12px; }
+    .heading-repo { color: #777; font-size: 14px; }
+    .heading-title { font-size: 18px; }
     .toolbar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; }
-    .btn-back { padding: 6px 14px; border: 1px solid #333; border-radius: 6px; background: transparent; color: #9e9e9e; font-size: 13px; cursor: pointer; }
+    .btn-back { padding: 6px 14px; border: 1px solid #252542; border-radius: 6px; background: #252542; color: #9e9e9e; font-size: 13px; cursor: pointer; }
     .toolbar-timer { display: flex; align-items: center; gap: 6px; color: #666; font-size: 12px; margin-left: auto; font-variant-numeric: tabular-nums; }
-    .btn-small { padding: 2px 8px; border: 1px solid #333; border-radius: 4px; background: transparent; color: #9e9e9e; font-size: 12px; cursor: pointer; }
-    .btn-small:hover { border-color: #666; color: #e0e0e0; }
+    .btn-small { padding: 2px 8px; border: 1px solid #252542; border-radius: 4px; background: #252542; color: #9e9e9e; font-size: 12px; cursor: pointer; }
+    .btn-small:hover { background: #2a2a50; border-color: #2a2a50; color: #e0e0e0; }
     .btn-small:disabled { opacity: 0.3; cursor: default; }
-    .btn-back:hover { border-color: #666; color: #e0e0e0; }
+    .btn-back:hover { background: #2a2a50; border-color: #2a2a50; color: #e0e0e0; }
     .targets { margin-top: 24px; }
     .targets h3 { color: #9e9e9e; font-size: 13px; margin-bottom: 8px; }
     .target { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border: 1px solid #333; border-radius: 6px; margin-bottom: 6px; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -5,11 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GHA Live</title>
   <style>
-    body { font-family: system-ui, sans-serif; background: #1a1a2e; padding: 24px; }
-    .error { color: #f44336; }
+    body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #e0e0e0; padding: 24px; }
+    .error { color: #f44336; margin-top: 12px; }
+    .muted { color: #9e9e9e; }
     .job-node { cursor: pointer; }
     @keyframes pulse { 50% { opacity: 0.6; } }
     .running { animation: pulse 1.5s ease-in-out infinite; }
+    .form-container { max-width: 480px; margin: 80px auto 0; }
+    .form-container h1 { color: #e0e0e0; margin-bottom: 4px; }
+    .form { display: flex; flex-direction: column; gap: 10px; margin-top: 16px; }
+    .input { padding: 10px 12px; border: 1px solid #333; border-radius: 6px; background: #16213e; color: #e0e0e0; font-size: 14px; outline: none; }
+    .input:focus { border-color: #2196f3; }
+    .input::placeholder { color: #666; }
+    .btn { padding: 10px 16px; border: none; border-radius: 6px; background: #2196f3; color: #fff; font-size: 14px; cursor: pointer; }
+    .btn:hover { background: #1976d2; }
+    .hint { color: #666; font-size: 12px; margin-top: 12px; }
   </style>
 </head>
 <body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -21,8 +21,11 @@
     .btn:hover { background: #1976d2; }
     .hint { color: #666; font-size: 12px; margin-top: 12px; }
     .layout { display: flex; gap: 16px; }
-    .sidebar { width: 180px; flex-shrink: 0; border-right: 1px solid #333; padding-right: 16px; }
-    .sidebar-title { color: #666; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+    .sidebar { width: 200px; flex-shrink: 0; border-right: 1px solid #333; padding-right: 16px; }
+    .sidebar-title { color: #666; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; margin-top: 12px; }
+    .sidebar-form { display: flex; flex-direction: column; gap: 6px; margin-bottom: 8px; }
+    .input-sm { padding: 6px 8px; font-size: 12px; }
+    .btn-sm { padding: 6px 10px; font-size: 12px; }
     .tree-owner { color: #9e9e9e; font-size: 12px; font-weight: 600; padding: 6px 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-ref { color: #9e9e9e; font-size: 12px; padding: 3px 8px 3px 16px; border-radius: 4px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
               pkgs.esbuild
               pkgs.nodejs_20
               pkgs.just
+              pkgs.python3
             ];
           };
         }

--- a/justfile
+++ b/justfile
@@ -15,5 +15,8 @@ lint:
 
 ci: lint build bundle
 
+serve: bundle
+    python3 -m http.server 8080 -d dist
+
 clean:
     rm -rf output/ dist/index.js

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ lint:
 ci: lint build bundle
 
 serve: bundle
-    python3 -m http.server 8080 -d dist
+    python3 -m http.server 10000 -d dist
 
 clean:
     rm -rf output/ dist/index.js

--- a/spago.lock
+++ b/spago.lock
@@ -16,8 +16,10 @@
             "foldable-traversable",
             "halogen",
             "halogen-svg-elems",
+            "integers",
             "maybe",
             "prelude",
+            "strings",
             "tuples",
             "web-dom",
             "web-html"

--- a/spago.yaml
+++ b/spago.yaml
@@ -17,6 +17,8 @@ package:
     - tuples
     - web-html
     - web-dom
+    - strings
+    - integers
   bundle:
     module: Main
     outfile: dist/index.js

--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -1,2 +1,197 @@
 -- | GitHub REST API client — fetch workflow runs, jobs, and statuses.
-module GitHub where
+module GitHub
+  ( Config
+  , Ref(..)
+  , WorkflowRun
+  , Job
+  , fetchPipeline
+  ) where
+
+import Prelude
+
+import Data.Argonaut.Core (Json, toObject)
+import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
+import Data.Argonaut.Decode.Combinators ((.:), (.:?))
+import Data.Argonaut.Decode.Error (JsonDecodeError(..))
+import Data.Argonaut.Parser (jsonParser)
+import Data.Array (concatMap)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.Traversable (traverse)
+import Effect.Aff (Aff, try)
+import Effect.Exception (message)
+import Fetch (fetch)
+import Foreign.Object as FO
+
+type Config =
+  { owner :: String
+  , repo :: String
+  , token :: String
+  , ref :: Ref
+  }
+
+data Ref
+  = PR Int
+  | SHA String
+  | Branch String
+
+type WorkflowRun =
+  { id :: Int
+  , name :: String
+  , status :: String
+  , conclusion :: Maybe String
+  , htmlUrl :: String
+  , headSha :: String
+  }
+
+type Job =
+  { id :: Int
+  , name :: String
+  , status :: String
+  , conclusion :: Maybe String
+  , htmlUrl :: String
+  , runId :: Int
+  }
+
+newtype WRun = WRun WorkflowRun
+
+instance DecodeJson WRun where
+  decodeJson json = case toObject json of
+    Nothing -> Left (TypeMismatch "Object")
+    Just obj -> do
+      id_ <- obj .: "id"
+      name_ <- obj .: "name"
+      status_ <- obj .: "status"
+      conclusion_ <- obj .:? "conclusion"
+      htmlUrl_ <- obj .: "html_url"
+      headSha_ <- obj .: "head_sha"
+      pure $ WRun
+        { id: id_
+        , name: name_
+        , status: status_
+        , conclusion: conclusion_
+        , htmlUrl: htmlUrl_
+        , headSha: headSha_
+        }
+
+newtype WJob = WJob Job
+
+instance DecodeJson WJob where
+  decodeJson json = case toObject json of
+    Nothing -> Left (TypeMismatch "Object")
+    Just obj -> do
+      id_ <- obj .: "id"
+      name_ <- obj .: "name"
+      status_ <- obj .: "status"
+      conclusion_ <- obj .:? "conclusion"
+      htmlUrl_ <- obj .: "html_url"
+      runId_ <- obj .: "run_id"
+      pure $ WJob
+        { id: id_
+        , name: name_
+        , status: status_
+        , conclusion: conclusion_
+        , htmlUrl: htmlUrl_
+        , runId: runId_
+        }
+
+ghFetch
+  :: Config
+  -> String
+  -> Aff (Either String Json)
+ghFetch cfg path = do
+  let
+    url =
+      "https://api.github.com/repos/"
+        <> cfg.owner
+        <> "/"
+        <> cfg.repo
+        <> path
+  result <- try do
+    resp <- fetch url
+      { headers:
+          { "Accept": "application/vnd.github.v3+json"
+          , "Authorization": "Bearer " <> cfg.token
+          }
+      }
+    resp.text
+  case result of
+    Left err -> pure $ Left (message err)
+    Right body -> case jsonParser body of
+      Left e -> pure $ Left ("JSON parse error: " <> e)
+      Right json -> pure $ Right json
+
+decodeField
+  :: forall a
+   . DecodeJson a
+  => String
+  -> Json
+  -> Either String a
+decodeField field json = case toObject json of
+  Nothing -> Left "Expected JSON object"
+  Just obj -> case FO.lookup field obj of
+    Nothing -> Left ("Missing field: " <> field)
+    Just arr -> case decodeJson arr of
+      Left err -> Left (show err)
+      Right val -> pure val
+
+fetchRuns
+  :: Config -> Aff (Either String (Array WorkflowRun))
+fetchRuns cfg = do
+  sha <- resolveRef cfg
+  case sha of
+    Left err -> pure (Left err)
+    Right headSha -> do
+      result <- ghFetch cfg
+        ( "/actions/runs?head_sha=" <> headSha
+            <> "&per_page=100"
+        )
+      pure $ result >>= \json -> do
+        runs :: Array WRun <- decodeField "workflow_runs" json
+        pure $ map (\(WRun r) -> r) runs
+
+resolveRef :: Config -> Aff (Either String String)
+resolveRef cfg = case cfg.ref of
+  SHA s -> pure (Right s)
+  Branch b -> do
+    result <- ghFetch cfg ("/commits/" <> b)
+    pure $ result >>= \json -> decodeField "sha" json
+  PR n -> do
+    result <- ghFetch cfg ("/pulls/" <> show n)
+    pure $ result >>= \json -> do
+      head :: { sha :: String } <- decodeField "head" json
+      pure head.sha
+
+fetchJobs
+  :: Config -> Int -> Aff (Either String (Array Job))
+fetchJobs cfg runId = do
+  result <- ghFetch cfg
+    ("/actions/runs/" <> show runId <> "/jobs?per_page=100")
+  pure $ result >>= \json -> do
+    jobs :: Array WJob <- decodeField "jobs" json
+    pure $ map (\(WJob j) -> j) jobs
+
+fetchPipeline
+  :: Config
+  -> Aff
+       ( Either String
+           { runs :: Array WorkflowRun
+           , jobs :: Array Job
+           }
+       )
+fetchPipeline cfg = do
+  runsResult <- fetchRuns cfg
+  case runsResult of
+    Left err -> pure (Left err)
+    Right runs -> do
+      jobResults <- traverse
+        (\r -> fetchJobs cfg r.id)
+        runs
+      let
+        allJobs = concatMap
+          ( case _ of
+              Left _ -> []
+              Right js -> js
+          )
+          jobResults
+      pure $ Right { runs, jobs: allJobs }

--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -143,7 +143,7 @@ ghFetch cfg path = do
       { headers:
           { "Accept": "application/vnd.github.v3+json"
           , "Authorization": "Bearer " <> cfg.token
-          , "Cache-Control": "no-cache"
+          , "If-None-Match": ""
           }
       }
     body <- resp.text

--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -21,6 +21,7 @@ import Data.Traversable (traverse)
 import Effect.Aff (Aff, try)
 import Effect.Exception (message)
 import Fetch (fetch)
+import Data.Number.Format as NF
 import Foreign.Object as FO
 
 type Config =
@@ -36,7 +37,7 @@ data Ref
   | Branch String
 
 type WorkflowRun =
-  { id :: Int
+  { id :: Number
   , name :: String
   , status :: String
   , conclusion :: Maybe String
@@ -45,12 +46,12 @@ type WorkflowRun =
   }
 
 type Job =
-  { id :: Int
+  { id :: Number
   , name :: String
   , status :: String
   , conclusion :: Maybe String
   , htmlUrl :: String
-  , runId :: Int
+  , runId :: Number
   }
 
 newtype WRun = WRun WorkflowRun
@@ -163,10 +164,10 @@ resolveRef cfg = case cfg.ref of
       pure head.sha
 
 fetchJobs
-  :: Config -> Int -> Aff (Either String (Array Job))
+  :: Config -> Number -> Aff (Either String (Array Job))
 fetchJobs cfg runId = do
   result <- ghFetch cfg
-    ("/actions/runs/" <> show runId <> "/jobs?per_page=100")
+    ("/actions/runs/" <> showId runId <> "/jobs?per_page=100")
   pure $ result >>= \json -> do
     jobs :: Array WJob <- decodeField "jobs" json
     pure $ map (\(WJob j) -> j) jobs
@@ -195,3 +196,6 @@ fetchPipeline cfg = do
           )
           jobResults
       pure $ Right { runs, jobs: allJobs }
+
+showId :: Number -> String
+showId = NF.toString

--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -143,6 +143,7 @@ ghFetch cfg path = do
       { headers:
           { "Accept": "application/vnd.github.v3+json"
           , "Authorization": "Bearer " <> cfg.token
+          , "Cache-Control": "no-cache"
           }
       }
     body <- resp.text

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -769,7 +769,14 @@ refLabel = case _ of
 
 addTarget :: Target -> Array Target -> Array Target
 addTarget t ts =
-  if any (\x -> x.url == t.url) ts then ts
+  if any (\x -> x.url == t.url) ts then
+    map
+      ( \x ->
+          if x.url == t.url && t.title /= "" then
+            x { title = t.title }
+          else x
+      )
+      ts
   else snoc ts t
 
 -- localStorage helpers

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -334,7 +334,7 @@ renderRefItem parts =
         HH.span
           [ HP.class_ (HH.ClassName "tree-ref-title") ]
           [ HH.text
-              (" " <> truncate 24 parts.target.title)
+              (" " <> truncate 44 parts.target.title)
           ]
     ]
   where

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -63,7 +63,8 @@ type State =
   , tickSub :: Maybe H.SubscriptionId
   , showSidebarForm :: Boolean
   , showTokenForm :: Boolean
-  , heading :: String
+  , headingRepo :: String
+  , headingTitle :: String
   }
 
 data Action
@@ -112,7 +113,8 @@ rootComponent =
         , tickSub: Nothing
         , showSidebarForm: false
         , showTokenForm: false
-        , heading: ""
+        , headingRepo: ""
+        , headingTitle: ""
         }
     , render
     , eval: H.mkEval H.defaultEval
@@ -131,11 +133,23 @@ render state = case state.config of
       , HH.div
           [ HP.class_ (HH.ClassName "main") ]
           ( [ renderToolbar state
-            , if state.heading == "" then HH.text ""
+            , if state.headingRepo == "" then HH.text ""
               else
                 HH.h2
                   [ HP.class_ (HH.ClassName "heading") ]
-                  [ HH.text state.heading ]
+                  [ HH.span
+                      [ HP.class_
+                          (HH.ClassName "heading-repo")
+                      ]
+                      [ HH.text
+                          (state.headingRepo <> " — ")
+                      ]
+                  , HH.span
+                      [ HP.class_
+                          (HH.ClassName "heading-title")
+                      ]
+                      [ HH.text state.headingTitle ]
+                  ]
             ]
               <>
                 if state.loading && null state.pipeline then
@@ -780,9 +794,8 @@ doFetch cfg = do
             , rateLimit = rl'
             , interval = newInterval
             , targets = merged
-            , heading = cfg.owner <> "/" <> cfg.repo
-                <> " — "
-                <> title
+            , headingRepo = cfg.owner <> "/" <> cfg.repo
+            , headingTitle = title
             }
           liftEffect $ saveTargets merged
 

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -324,11 +324,6 @@ renderToolbar state =
   HH.div
     [ HP.class_ (HH.ClassName "toolbar") ]
     [ HH.button
-        [ HE.onClick \_ -> Back
-        , HP.class_ (HH.ClassName "btn-back")
-        ]
-        [ HH.text "Back" ]
-    , HH.button
         [ HE.onClick \_ -> Refresh
         , HP.class_ (HH.ClassName "btn-back")
         , HP.disabled state.loading

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -6,7 +6,7 @@ import Data.Argonaut.Core (Json, stringify)
 import Data.Argonaut.Decode.Class (decodeJson)
 import Data.Argonaut.Encode.Class (encodeJson)
 import Data.Argonaut.Parser (jsonParser)
-import Data.Array (filter, foldl, index, length, nub, null, snoc)
+import Data.Array (any, filter, foldl, index, length, nub, null, snoc)
 import Data.Either (Either(..), hush)
 import Data.Int (ceil, fromString, toNumber) as Int
 import Data.Maybe (Maybe(..), fromMaybe)
@@ -615,7 +615,8 @@ refLabel = case _ of
 
 addTarget :: Target -> Array Target -> Array Target
 addTarget t ts =
-  nub $ snoc (filter (\x -> x.url /= t.url) ts) t
+  if any (\x -> x.url == t.url) ts then ts
+  else snoc ts t
 
 -- localStorage helpers
 

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -216,15 +216,44 @@ buildTree targets =
       )
       owners
 
+renderInputs
+  :: forall w. State -> Array (HH.HTML w Action)
+renderInputs state =
+  [ HH.div
+      [ HP.class_ (HH.ClassName "sidebar-form") ]
+      [ HH.input
+          [ HP.type_ HP.InputText
+          , HP.placeholder "GitHub URL"
+          , HP.value state.formUrl
+          , HE.onValueInput SetFormUrl
+          , HP.class_ (HH.ClassName "input input-sm")
+          ]
+      , HH.input
+          [ HP.type_ HP.InputPassword
+          , HP.placeholder "Token"
+          , HP.value state.formToken
+          , HE.onValueInput SetFormToken
+          , HP.class_ (HH.ClassName "input input-sm")
+          ]
+      , HH.button
+          [ HE.onClick \_ -> Submit
+          , HP.class_ (HH.ClassName "btn btn-sm")
+          ]
+          [ HH.text "Watch" ]
+      ]
+  ]
+
 renderSidebar
   :: forall w. State -> HH.HTML w Action
 renderSidebar state =
   HH.div
     [ HP.class_ (HH.ClassName "sidebar") ]
-    ( [ HH.div
-          [ HP.class_ (HH.ClassName "sidebar-title") ]
-          [ HH.text "Targets" ]
-      ]
+    ( renderInputs state
+        <>
+          [ HH.div
+              [ HP.class_ (HH.ClassName "sidebar-title") ]
+              [ HH.text "Targets" ]
+          ]
         <> bind (buildTree state.targets)
           renderOwnerNode
     )

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -225,12 +225,26 @@ renderInputs state =
   if state.showSidebarForm then
     [ HH.div
         [ HP.class_ (HH.ClassName "sidebar-form") ]
-        [ HH.input
-            [ HP.type_ HP.InputText
-            , HP.placeholder "GitHub URL"
-            , HP.value state.formUrl
-            , HE.onValueInput SetFormUrl
-            , HP.class_ (HH.ClassName "input input-sm")
+        [ HH.div
+            [ HP.class_ (HH.ClassName "sidebar-form-row") ]
+            [ HH.input
+                [ HP.type_ HP.InputText
+                , HP.placeholder "GitHub URL"
+                , HP.value state.formUrl
+                , HE.onValueInput SetFormUrl
+                , HP.class_
+                    (HH.ClassName "input input-sm url-input")
+                ]
+            , HH.button
+                [ HE.onClick \_ -> Submit
+                , HP.class_ (HH.ClassName "btn btn-sm")
+                ]
+                [ HH.text "Watch" ]
+            , HH.button
+                [ HE.onClick \_ -> ToggleSidebarForm
+                , HP.class_ (HH.ClassName "btn-small")
+                ]
+                [ HH.text "x" ]
             ]
         , HH.input
             [ HP.type_ HP.InputPassword
@@ -238,20 +252,6 @@ renderInputs state =
             , HP.value state.formToken
             , HE.onValueInput SetFormToken
             , HP.class_ (HH.ClassName "input input-sm")
-            ]
-        , HH.div
-            [ HP.class_ (HH.ClassName "sidebar-form-row") ]
-            [ HH.button
-                [ HE.onClick \_ -> Submit
-                , HP.class_ (HH.ClassName "btn btn-sm")
-                ]
-                [ HH.text "Watch" ]
-            , HH.button
-                [ HE.onClick \_ -> ToggleSidebarForm
-                , HP.class_
-                    (HH.ClassName "btn-small")
-                ]
-                [ HH.text "Cancel" ]
             ]
         ]
     ]

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -2,21 +2,193 @@ module Main where
 
 import Prelude
 
+import Data.Array (filter, null)
+import Data.Either (Either(..))
+import Data.Int (fromString) as Int
+import Data.Maybe (Maybe(..))
+import Data.String (Pattern(..), drop, indexOf, split, take)
 import Effect (Effect)
+import Effect.Aff (Aff, Milliseconds(..), delay)
+import Effect.Aff as Aff
+import Effect.Class (liftEffect)
+import GitHub (Config, Ref(..), fetchPipeline)
 import Halogen as H
 import Halogen.Aff as HA
 import Halogen.HTML as HH
+import Halogen.HTML.Properties as HP
+import Halogen.Subscription as HS
 import Halogen.VDom.Driver (runUI)
+import Pipeline (RunView, buildPipeline)
+import View (renderPipeline)
+import Web.HTML (window)
+import Web.HTML.Location (search)
+import Web.HTML.Window (location)
+import Web.HTML.Window as Window
 
 main :: Effect Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
   runUI rootComponent unit body
 
-rootComponent :: forall q i o m. H.Component q i o m
+type State =
+  { config :: Maybe Config
+  , pipeline :: Array RunView
+  , error :: Maybe String
+  , loading :: Boolean
+  }
+
+data Action
+  = Initialize
+  | Tick
+  | OpenUrl String
+
+rootComponent
+  :: forall q i o. H.Component q i o Aff
 rootComponent =
   H.mkComponent
-    { initialState: \_ -> unit
-    , render: \_ -> HH.h1_ [ HH.text "GHA Live" ]
+    { initialState: \_ ->
+        { config: Nothing
+        , pipeline: []
+        , error: Nothing
+        , loading: false
+        }
+    , render
     , eval: H.mkEval H.defaultEval
+        { handleAction = handleAction
+        , initialize = Just Initialize
+        }
     }
+
+render :: State -> H.ComponentHTML Action () Aff
+render state
+  | state.loading && null state.pipeline =
+      HH.div_ [ HH.text "Loading..." ]
+  | otherwise =
+      HH.div_
+        ( case state.error of
+            Just err ->
+              [ HH.div
+                  [ HP.class_ (HH.ClassName "error") ]
+                  [ HH.text err ]
+              ]
+            Nothing -> []
+            <>
+              if null state.pipeline then
+                [ HH.div_ [ HH.text "No workflow runs found." ]
+                ]
+              else
+                [ renderPipeline OpenUrl state.pipeline ]
+        )
+
+handleAction
+  :: forall o
+   . Action
+  -> H.HalogenM State Action () o Aff Unit
+handleAction = case _ of
+  Initialize -> do
+    qs <- liftEffect do
+      w <- window
+      loc <- location w
+      search loc
+    case parseConfig qs of
+      Nothing ->
+        H.modify_ _
+          { error = Just
+              "Missing query params. Use ?owner=X&repo=Y&token=Z&branch=main (or &pr=N or &sha=ABC)"
+          }
+      Just cfg -> do
+        H.modify_ _ { config = Just cfg, loading = true }
+        doFetch cfg
+        _ <- H.subscribe $ ticker 5000.0
+        pure unit
+  Tick -> do
+    st <- H.get
+    case st.config of
+      Nothing -> pure unit
+      Just cfg -> doFetch cfg
+  OpenUrl url -> liftEffect do
+    w <- window
+    void $ Window.open url "_blank" "" w
+
+doFetch
+  :: forall o
+   . Config
+  -> H.HalogenM State Action () o Aff Unit
+doFetch cfg = do
+  result <- H.liftAff (fetchPipeline cfg)
+  case result of
+    Left err ->
+      H.modify_ _
+        { error = Just err, loading = false }
+    Right { runs, jobs } ->
+      H.modify_ _
+        { pipeline = buildPipeline runs jobs
+        , error = Nothing
+        , loading = false
+        }
+
+ticker :: Number -> HS.Emitter Action
+ticker ms = HS.makeEmitter \emit -> do
+  fiber <- Aff.launchAff do
+    loop emit
+  pure $ Aff.launchAff_ (Aff.killFiber (Aff.error "unsubscribe") fiber)
+  where
+  loop emit = do
+    delay (Milliseconds ms)
+    liftEffect (emit Tick)
+    loop emit
+
+parseConfig :: String -> Maybe Config
+parseConfig qs = do
+  let params = parseParams qs
+  owner <- lookup' "owner" params
+  repo <- lookup' "repo" params
+  token <- lookup' "token" params
+  ref <- parseRef params
+  pure { owner, repo, token, ref }
+
+parseRef
+  :: Array { key :: String, value :: String }
+  -> Maybe Ref
+parseRef params =
+  case lookup' "pr" params of
+    Just pr -> case Int.fromString pr of
+      Just n -> Just (PR n)
+      Nothing -> Nothing
+    Nothing -> case lookup' "sha" params of
+      Just sha -> Just (SHA sha)
+      Nothing -> case lookup' "branch" params of
+        Just b -> Just (Branch b)
+        Nothing -> Nothing
+
+parseParams
+  :: String
+  -> Array { key :: String, value :: String }
+parseParams qs =
+  let
+    stripped = case indexOf (Pattern "?") qs of
+      Just i -> drop (i + 1) qs
+      Nothing -> qs
+    pairs = filter (\s -> s /= "") $ split (Pattern "&") stripped
+  in
+    map parsePair pairs
+
+parsePair
+  :: String -> { key :: String, value :: String }
+parsePair s =
+  case indexOf (Pattern "=") s of
+    Just i ->
+      { key: take i s
+      , value: drop (i + 1) s
+      }
+    Nothing ->
+      { key: s, value: "" }
+
+lookup'
+  :: String
+  -> Array { key :: String, value :: String }
+  -> Maybe String
+lookup' k params =
+  case filter (\p -> p.key == k) params of
+    [ p ] -> Just p.value
+    _ -> Nothing

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -103,33 +103,60 @@ render :: State -> H.ComponentHTML Action () Aff
 render state = case state.config of
   Nothing -> renderForm state
   Just _ ->
-    if state.loading && null state.pipeline then
-      HH.div_
-        [ renderToolbar state
-        , HH.text "Loading..."
-        ]
-    else
-      HH.div_
-        ( [ renderToolbar state ]
-            <> case state.error of
-              Just err ->
-                [ HH.div
-                    [ HP.class_ (HH.ClassName "error") ]
-                    [ HH.text err ]
-                ]
-              Nothing -> []
-            <>
-              if null state.pipeline then
-                [ HH.div
-                    [ HP.class_ (HH.ClassName "muted") ]
-                    [ HH.text
-                        "No workflow runs found."
-                    ]
-                ]
-              else
-                [ renderPipeline state.pipeline
-                ]
-        )
+    HH.div
+      [ HP.class_ (HH.ClassName "layout") ]
+      [ renderSidebar state
+      , HH.div
+          [ HP.class_ (HH.ClassName "main") ]
+          ( [ renderToolbar state ]
+              <>
+                if state.loading && null state.pipeline then
+                  [ HH.text "Loading..." ]
+                else
+                  ( case state.error of
+                      Just err ->
+                        [ HH.div
+                            [ HP.class_ (HH.ClassName "error") ]
+                            [ HH.text err ]
+                        ]
+                      Nothing -> []
+                      <>
+                        if null state.pipeline then
+                          [ HH.div
+                              [ HP.class_
+                                  (HH.ClassName "muted")
+                              ]
+                              [ HH.text
+                                  "No workflow runs found."
+                              ]
+                          ]
+                        else
+                          [ renderPipeline state.pipeline
+                          ]
+                  )
+          )
+      ]
+
+renderSidebar
+  :: forall w. State -> HH.HTML w Action
+renderSidebar state =
+  HH.div
+    [ HP.class_ (HH.ClassName "sidebar") ]
+    ( [ HH.div
+          [ HP.class_ (HH.ClassName "sidebar-title") ]
+          [ HH.text "Targets" ]
+      ]
+        <> map renderSidebarTarget state.targets
+    )
+
+renderSidebarTarget
+  :: forall w. Target -> HH.HTML w Action
+renderSidebarTarget target =
+  HH.div
+    [ HE.onClick \_ -> SelectTarget target
+    , HP.class_ (HH.ClassName "sidebar-item")
+    ]
+    [ HH.text target.label ]
 
 renderToolbar
   :: forall w. State -> HH.HTML w Action

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -29,7 +29,6 @@ import View (renderPipeline)
 import Web.HTML (window)
 import Web.HTML.Location (search)
 import Web.HTML.Window (localStorage, location)
-import Web.HTML.Window as Window
 import Web.Storage.Storage as Storage
 
 main :: Effect Unit
@@ -55,7 +54,6 @@ type State =
 data Action
   = Initialize
   | Tick
-  | OpenUrl String
   | SetFormUrl String
   | SetFormToken String
   | Submit
@@ -121,7 +119,7 @@ render state = case state.config of
                     ]
                 ]
               else
-                [ renderPipeline OpenUrl state.pipeline
+                [ renderPipeline state.pipeline
                 ]
         )
 
@@ -304,9 +302,6 @@ handleAction = case _ of
     case st.config of
       Nothing -> pure unit
       Just cfg -> doFetch cfg
-  OpenUrl url -> liftEffect do
-    w <- window
-    void $ Window.open url "_blank" "" w
 
 startWatching
   :: forall o

--- a/src/Pipeline.purs
+++ b/src/Pipeline.purs
@@ -22,14 +22,14 @@ data Status
   | Skipped
 
 type JobView =
-  { id :: Int
+  { id :: Number
   , name :: String
   , status :: Status
   , htmlUrl :: String
   }
 
 type RunView =
-  { id :: Int
+  { id :: Number
   , name :: String
   , status :: Status
   , jobs :: Array JobView
@@ -61,7 +61,7 @@ buildPipeline runs jobs =
     , jobs: map toJobView (jobsForRun run.id)
     }
 
-  jobsForRun :: Int -> Array Job
+  jobsForRun :: Number -> Array Job
   jobsForRun runId = filter (\j -> j.runId == runId) jobs
 
   toJobView :: Job -> JobView

--- a/src/Pipeline.purs
+++ b/src/Pipeline.purs
@@ -1,2 +1,73 @@
 -- | Pipeline model — build the DAG of workflows and jobs from API data.
-module Pipeline where
+module Pipeline
+  ( Status(..)
+  , JobView
+  , RunView
+  , buildPipeline
+  ) where
+
+import Prelude
+
+import Data.Array (filter)
+import Data.Maybe (Maybe(..))
+import GitHub (WorkflowRun, Job)
+
+data Status
+  = Pending
+  | Queued
+  | Running
+  | Success
+  | Failure
+  | Cancelled
+  | Skipped
+
+type JobView =
+  { id :: Int
+  , name :: String
+  , status :: Status
+  , htmlUrl :: String
+  }
+
+type RunView =
+  { id :: Int
+  , name :: String
+  , status :: Status
+  , jobs :: Array JobView
+  }
+
+toStatus :: String -> Maybe String -> Status
+toStatus status conclusion = case status, conclusion of
+  "queued", _ -> Queued
+  "in_progress", _ -> Running
+  "waiting", _ -> Pending
+  "pending", _ -> Pending
+  "completed", Just "success" -> Success
+  "completed", Just "failure" -> Failure
+  "completed", Just "cancelled" -> Cancelled
+  "completed", Just "skipped" -> Skipped
+  "completed", _ -> Failure
+  _, _ -> Pending
+
+buildPipeline
+  :: Array WorkflowRun -> Array Job -> Array RunView
+buildPipeline runs jobs =
+  map buildRun runs
+  where
+  buildRun :: WorkflowRun -> RunView
+  buildRun run =
+    { id: run.id
+    , name: run.name
+    , status: toStatus run.status run.conclusion
+    , jobs: map toJobView (jobsForRun run.id)
+    }
+
+  jobsForRun :: Int -> Array Job
+  jobsForRun runId = filter (\j -> j.runId == runId) jobs
+
+  toJobView :: Job -> JobView
+  toJobView job =
+    { id: job.id
+    , name: job.name
+    , status: toStatus job.status job.conclusion
+    , htmlUrl: job.htmlUrl
+    }

--- a/src/View.purs
+++ b/src/View.purs
@@ -1,2 +1,145 @@
 -- | View — render the pipeline DAG as SVG with Halogen.
-module View where
+module View
+  ( renderPipeline
+  ) where
+
+import Prelude
+
+import Data.Array (foldl, length, mapWithIndex)
+import Data.Int (toNumber)
+import Data.Tuple (Tuple(..), snd)
+import Halogen.HTML as HH
+import Halogen.HTML.Core (ClassName(..))
+import Halogen.HTML.Events as HE
+import Halogen.Svg.Attributes as SA
+import Halogen.Svg.Attributes.Color (Color(..))
+import Halogen.Svg.Attributes.CSSLength (CSSLength(..))
+import Halogen.Svg.Attributes.FontSize (FontSize(..))
+import Halogen.Svg.Attributes.TextAnchor (TextAnchor(..))
+import Halogen.Svg.Elements as SE
+import Pipeline (JobView, RunView, Status(..))
+
+statusColor :: Status -> Color
+statusColor = case _ of
+  Pending -> Named "#9e9e9e"
+  Queued -> Named "#ffc107"
+  Running -> Named "#2196f3"
+  Success -> Named "#4caf50"
+  Failure -> Named "#f44336"
+  Cancelled -> Named "#ff9800"
+  Skipped -> Named "#bdbdbd"
+
+rowHeight :: Number
+rowHeight = 60.0
+
+labelWidth :: Number
+labelWidth = 180.0
+
+jobWidth :: Number
+jobWidth = 120.0
+
+jobHeight :: Number
+jobHeight = 36.0
+
+jobGap :: Number
+jobGap = 12.0
+
+padding :: Number
+padding = 16.0
+
+renderPipeline
+  :: forall w a
+   . (String -> a)
+  -> Array RunView
+  -> HH.HTML w a
+renderPipeline onClick runs =
+  let
+    maxJobs = foldi 0 (\_ acc r -> max acc (length r.jobs)) runs
+    svgW = labelWidth + (toNumber maxJobs) * (jobWidth + jobGap) + padding * 2.0
+    svgH = (toNumber (length runs)) * rowHeight + padding * 2.0
+  in
+    SE.svg
+      [ SA.viewBox 0.0 0.0 svgW svgH
+      , SA.width svgW
+      , SA.height svgH
+      ]
+      (mapWithIndex (renderRun onClick) runs)
+
+renderRun
+  :: forall w a
+   . (String -> a)
+  -> Int
+  -> RunView
+  -> HH.HTML w a
+renderRun onClick rowIdx run =
+  let
+    yOff = padding + (toNumber rowIdx) * rowHeight + rowHeight / 2.0
+  in
+    SE.g []
+      ( [ SE.text
+            [ SA.x (padding + 4.0)
+            , SA.y yOff
+            , SA.fill (Named "#e0e0e0")
+            , SA.fontSize (FontSizeLength (Px 13.0))
+            , SA.textAnchor AnchorStart
+            , SA.class_ (ClassName "run-label")
+            ]
+            [ HH.text run.name ]
+        ]
+          <> mapWithIndex (renderJob onClick rowIdx) run.jobs
+      )
+
+renderJob
+  :: forall w a
+   . (String -> a)
+  -> Int
+  -> Int
+  -> JobView
+  -> HH.HTML w a
+renderJob onClick rowIdx colIdx job =
+  let
+    xOff = labelWidth + (toNumber colIdx) * (jobWidth + jobGap)
+    yOff = padding + (toNumber rowIdx) * rowHeight + (rowHeight - jobHeight) / 2.0
+    classes = case job.status of
+      Running -> [ ClassName "job-node", ClassName "running" ]
+      _ -> [ ClassName "job-node" ]
+  in
+    SE.g
+      [ HE.onClick (\_ -> onClick job.htmlUrl)
+      , SA.classes classes
+      ]
+      [ SE.rect
+          [ SA.x xOff
+          , SA.y yOff
+          , SA.width jobWidth
+          , SA.height jobHeight
+          , SA.rx 6.0
+          , SA.ry 6.0
+          , SA.fill (statusColor job.status)
+          ]
+      , SE.text
+          [ SA.x (xOff + jobWidth / 2.0)
+          , SA.y (yOff + jobHeight / 2.0 + 4.0)
+          , SA.fill (Named "#ffffff")
+          , SA.fontSize (FontSizeLength (Px 11.0))
+          , SA.textAnchor AnchorMiddle
+          , SA.class_ (ClassName "job-label")
+          ]
+          [ HH.text job.name ]
+      ]
+
+foldi
+  :: forall a b
+   . b
+  -> (Int -> b -> a -> b)
+  -> Array a
+  -> b
+foldi init f arr =
+  snd
+    ( foldl
+        ( \(Tuple idx acc) x ->
+            Tuple (idx + 1) (f idx acc x)
+        )
+        (Tuple 0 init)
+        arr
+    )

--- a/src/View.purs
+++ b/src/View.purs
@@ -125,6 +125,7 @@ renderRun runs colIdx run =
   let
     xOff = colOffset runs colIdx
     w = colWidth run
+    sepY = padding + labelH + 6.0
   in
     SE.g []
       ( [ SE.text
@@ -136,6 +137,14 @@ renderRun runs colIdx run =
             , SA.class_ (ClassName "run-label")
             ]
             [ HH.text run.name ]
+        , SE.line
+            [ SA.x1 xOff
+            , SA.y1 sepY
+            , SA.x2 (xOff + w)
+            , SA.y2 sepY
+            , SA.stroke (Named "#333")
+            , SA.strokeWidth 1.0
+            ]
         ]
           <> mapWithIndex
             (renderJob xOff w)

--- a/src/View.purs
+++ b/src/View.purs
@@ -5,15 +5,17 @@ module View
 
 import Prelude
 
+import Data.Array as Array
 import Data.Array (foldl, length, mapWithIndex)
 import Data.Int (toNumber)
-import Data.Tuple (Tuple(..), snd)
+import Data.Maybe (Maybe(..))
+import Data.String.CodeUnits (length) as S
 import Halogen.HTML as HH
 import Halogen.HTML.Core (ClassName(..))
 import Halogen.HTML.Events as HE
 import Halogen.Svg.Attributes as SA
-import Halogen.Svg.Attributes.Color (Color(..))
 import Halogen.Svg.Attributes.CSSLength (CSSLength(..))
+import Halogen.Svg.Attributes.Color (Color(..))
 import Halogen.Svg.Attributes.FontSize (FontSize(..))
 import Halogen.Svg.Attributes.TextAnchor (TextAnchor(..))
 import Halogen.Svg.Elements as SE
@@ -29,23 +31,74 @@ statusColor = case _ of
   Cancelled -> Named "#ff9800"
   Skipped -> Named "#bdbdbd"
 
-rowHeight :: Number
-rowHeight = 60.0
-
-labelWidth :: Number
-labelWidth = 180.0
-
-jobWidth :: Number
-jobWidth = 120.0
-
-jobHeight :: Number
-jobHeight = 36.0
+jobH :: Number
+jobH = 30.0
 
 jobGap :: Number
-jobGap = 12.0
+jobGap = 8.0
+
+colGap :: Number
+colGap = 24.0
 
 padding :: Number
 padding = 16.0
+
+labelH :: Number
+labelH = 20.0
+
+charW :: Number
+charW = 7.0
+
+hPad :: Number
+hPad = 16.0
+
+textWidth :: String -> Number
+textWidth s = toNumber (S.length s) * charW + hPad
+
+colWidth :: RunView -> Number
+colWidth run =
+  foldl
+    ( \acc j ->
+        max acc (textWidth j.name)
+    )
+    (textWidth run.name)
+    run.jobs
+
+colOffset :: Array RunView -> Int -> Number
+colOffset runs idx =
+  foldl
+    ( \acc i ->
+        acc + colWidth' i + colGap
+    )
+    padding
+    (range 0 (idx - 1))
+  where
+  colWidth' i = case index' runs i of
+    Nothing -> 0.0
+    Just r -> colWidth r
+
+index' :: forall a. Array a -> Int -> Maybe a
+index' = Array.index
+
+range :: Int -> Int -> Array Int
+range lo hi
+  | lo > hi = []
+  | otherwise = map (\i -> lo + i) (Array.range 0 (hi - lo))
+
+svgWidth :: Array RunView -> Number
+svgWidth runs =
+  colOffset runs (length runs) - colGap + padding
+
+svgHeight :: Array RunView -> Number
+svgHeight runs =
+  let
+    maxJobs = foldl (\acc r -> max acc (length r.jobs)) 0
+      runs
+  in
+    padding + labelH + 12.0
+      + toNumber maxJobs
+          * (jobH + jobGap)
+      + padding
 
 renderPipeline
   :: forall w a
@@ -54,54 +107,61 @@ renderPipeline
   -> HH.HTML w a
 renderPipeline onClick runs =
   let
-    maxJobs = foldi 0 (\_ acc r -> max acc (length r.jobs)) runs
-    svgW = labelWidth + (toNumber maxJobs) * (jobWidth + jobGap) + padding * 2.0
-    svgH = (toNumber (length runs)) * rowHeight + padding * 2.0
+    w = svgWidth runs
+    h = svgHeight runs
   in
     SE.svg
-      [ SA.viewBox 0.0 0.0 svgW svgH
-      , SA.width svgW
-      , SA.height svgH
+      [ SA.viewBox 0.0 0.0 w h
+      , SA.width w
+      , SA.height h
       ]
-      (mapWithIndex (renderRun onClick) runs)
+      (mapWithIndex (renderRun onClick runs) runs)
 
 renderRun
   :: forall w a
    . (String -> a)
+  -> Array RunView
   -> Int
   -> RunView
   -> HH.HTML w a
-renderRun onClick rowIdx run =
+renderRun onClick runs colIdx run =
   let
-    yOff = padding + (toNumber rowIdx) * rowHeight + rowHeight / 2.0
+    xOff = colOffset runs colIdx
+    w = colWidth run
   in
     SE.g []
       ( [ SE.text
-            [ SA.x (padding + 4.0)
-            , SA.y yOff
+            [ SA.x (xOff + w / 2.0)
+            , SA.y (padding + labelH)
             , SA.fill (Named "#e0e0e0")
-            , SA.fontSize (FontSizeLength (Px 13.0))
-            , SA.textAnchor AnchorStart
+            , SA.fontSize (FontSizeLength (Px 12.0))
+            , SA.textAnchor AnchorMiddle
             , SA.class_ (ClassName "run-label")
             ]
             [ HH.text run.name ]
         ]
-          <> mapWithIndex (renderJob onClick rowIdx) run.jobs
+          <> mapWithIndex
+            (renderJob onClick xOff w)
+            run.jobs
       )
 
 renderJob
   :: forall w a
    . (String -> a)
-  -> Int
+  -> Number
+  -> Number
   -> Int
   -> JobView
   -> HH.HTML w a
-renderJob onClick rowIdx colIdx job =
+renderJob onClick xOff colW rowIdx job =
   let
-    xOff = labelWidth + (toNumber colIdx) * (jobWidth + jobGap)
-    yOff = padding + (toNumber rowIdx) * rowHeight + (rowHeight - jobHeight) / 2.0
+    boxW = textWidth job.name
+    xBox = xOff + (colW - boxW) / 2.0
+    yBox = padding + labelH + 12.0 + toNumber rowIdx
+      * (jobH + jobGap)
     classes = case job.status of
-      Running -> [ ClassName "job-node", ClassName "running" ]
+      Running ->
+        [ ClassName "job-node", ClassName "running" ]
       _ -> [ ClassName "job-node" ]
   in
     SE.g
@@ -109,17 +169,17 @@ renderJob onClick rowIdx colIdx job =
       , SA.classes classes
       ]
       [ SE.rect
-          [ SA.x xOff
-          , SA.y yOff
-          , SA.width jobWidth
-          , SA.height jobHeight
+          [ SA.x xBox
+          , SA.y yBox
+          , SA.width boxW
+          , SA.height jobH
           , SA.rx 6.0
           , SA.ry 6.0
           , SA.fill (statusColor job.status)
           ]
       , SE.text
-          [ SA.x (xOff + jobWidth / 2.0)
-          , SA.y (yOff + jobHeight / 2.0 + 4.0)
+          [ SA.x (xBox + boxW / 2.0)
+          , SA.y (yBox + jobH / 2.0 + 4.0)
           , SA.fill (Named "#ffffff")
           , SA.fontSize (FontSizeLength (Px 11.0))
           , SA.textAnchor AnchorMiddle
@@ -127,19 +187,3 @@ renderJob onClick rowIdx colIdx job =
           ]
           [ HH.text job.name ]
       ]
-
-foldi
-  :: forall a b
-   . b
-  -> (Int -> b -> a -> b)
-  -> Array a
-  -> b
-foldi init f arr =
-  snd
-    ( foldl
-        ( \(Tuple idx acc) x ->
-            Tuple (idx + 1) (f idx acc x)
-        )
-        (Tuple 0 init)
-        arr
-    )

--- a/src/View.purs
+++ b/src/View.purs
@@ -12,7 +12,6 @@ import Data.Maybe (Maybe(..))
 import Data.String.CodeUnits (length) as S
 import Halogen.HTML as HH
 import Halogen.HTML.Core (ClassName(..), ElemName(..))
-import Halogen.HTML.Properties as HP
 import Halogen.Svg.Attributes as SA
 import Halogen.Svg.Attributes.CSSLength (CSSLength(..))
 import Halogen.Svg.Attributes.Color (Color(..))
@@ -191,8 +190,6 @@ svgA
 svgA url classes children =
   SE.element (ElemName "a")
     [ SA.href url
-    , HP.attr (HH.AttrName "target") "_blank"
-    , HP.attr (HH.AttrName "rel") "noopener"
     , SA.classes classes
     ]
     children


### PR DESCRIPTION
## Summary

- GitHub REST API client with auth, PR/SHA/branch ref resolution, workflow runs and jobs fetching
- Pipeline domain model mapping API status/conclusion pairs to typed Status ADT
- SVG rendering with colored job boxes per workflow run, click-to-open, pulse animation
- Halogen component with GitHub URL form, localStorage persistence, and auto-polling
- Target sidebar with owner/repo/ref tree, add/remove repos, auto-discover open PRs
- Countdown timer with variable refresh interval, auto-tuned to rate limit budget
- API call count and rate limit display in toolbar
- PR titles shown in navigation, truncated for sidebar
- GitHub Pages deployment workflow