### PR TITLE
feat: color timer based on rate limit safety threshold

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -60,6 +60,8 @@
     .toolbar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; }
     .btn-back { padding: 6px 14px; border: 1px solid #252542; border-radius: 6px; background: #252542; color: #9e9e9e; font-size: 13px; cursor: pointer; }
     .toolbar-timer { display: flex; align-items: center; gap: 6px; color: #666; font-size: 12px; margin-left: auto; font-variant-numeric: tabular-nums; }
+    .timer-safe { color: #4caf50; }
+    .timer-unsafe { color: #f44336; }
     .btn-small { padding: 2px 8px; border: 1px solid #252542; border-radius: 4px; background: #252542; color: #9e9e9e; font-size: 12px; cursor: pointer; }
     .btn-small:hover { background: #2a2a50; border-color: #2a2a50; color: #e0e0e0; }
     .btn-small:disabled { opacity: 0.3; cursor: default; }


### PR DESCRIPTION
## Summary

- Track auto-computed safe interval separately from user-set interval
- Color timer green when interval >= safe threshold, red when below
- User can still manually adjust interval; color reflects safety status