### PR TITLE
docs: add link to hosted app in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gha-live
 
+**https://paolino.github.io/gha-live/**
+
 Live pipeline visualization for GitHub Actions — all workflows and jobs for a commit or PR on a single page, rendered as a color-coded DAG with auto-refresh and clickable links to logs.
 
 **Runs entirely in your browser.** There is no server — the app is a static page hosted on GitHub Pages. Your GitHub token is stored in localStorage and sent only to the GitHub API. Nothing is logged or transmitted to any third party.


### PR DESCRIPTION
## Summary

- Add the GitHub Pages URL at the top of the README