### PR TITLE
feat: mobile-friendly page switching for sidebar and diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Live pipeline visualization for GitHub Actions — all workflows and jobs for a commit or PR on a single page, rendered as a color-coded DAG with auto-refresh and clickable links to logs.
 
+**Runs entirely in your browser.** There is no server — the app is a static page hosted on GitHub Pages. Your GitHub token is stored in localStorage and sent only to the GitHub API. Nothing is logged or transmitted to any third party.
+
 ## Stack
 
 PureScript · Halogen · SVG · GitHub REST API · esbuild

--- a/dist/index.html
+++ b/dist/index.html
@@ -75,6 +75,17 @@
     .target-title { color: #777; font-size: 12px; font-weight: 400; }
     .target-remove { color: #666; cursor: pointer; font-size: 12px; padding: 2px 6px; }
     .target-remove:hover { color: #f44336; }
+    .main svg { max-width: 100%; overflow-x: auto; display: block; }
+    @media (max-width: 700px) {
+      body { padding: 12px; }
+      .form-container { margin-top: 32px; }
+      .layout { flex-direction: column; }
+      .sidebar { width: 100%; border-right: none; padding-right: 0; border-bottom: 1px solid #333; padding-bottom: 12px; margin-bottom: 12px; }
+      .toolbar { flex-wrap: wrap; }
+      .toolbar-timer { margin-left: 0; }
+      .heading-title { font-size: 16px; }
+      .main { overflow-x: auto; }
+    }
   </style>
 </head>
 <body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -42,8 +42,9 @@
     .btn-add { width: 100%; padding: 4px; border: 1px dashed #252542; border-radius: 6px; background: #252542; color: #666; font-size: 16px; cursor: pointer; margin-bottom: 8px; }
     .btn-add:hover { background: #2a2a50; border-color: #2a2a50; color: #9e9e9e; }
     .btn-add-token { font-size: 14px; padding: 2px; }
-    .btn-reset { width: 100%; padding: 4px; border: 1px solid #252542; border-radius: 6px; background: #252542; color: #555; font-size: 11px; cursor: pointer; margin-top: 16px; }
-    .btn-reset:hover { background: #2a2a50; border-color: #2a2a50; color: #f44336; }
+    .sidebar-actions { display: flex; gap: 4px; margin-top: 16px; }
+    .btn-reset { flex: 1; padding: 4px; border: 1px solid #252542; border-radius: 6px; background: #252542; color: #555; font-size: 11px; cursor: pointer; }
+    .btn-reset:hover { background: #2a2a50; border-color: #2a2a50; color: #9e9e9e; }
     .tree-owner { color: #9e9e9e; font-size: 12px; font-weight: 600; padding: 6px 0 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; justify-content: space-between; }
     .tree-remove { color: #555; cursor: pointer; font-size: 10px; padding: 0 4px; flex-shrink: 0; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -75,11 +75,15 @@
     .target-title { color: #777; font-size: 12px; font-weight: 400; }
     .target-remove { color: #666; cursor: pointer; font-size: 12px; padding: 2px 6px; }
     .target-remove:hover { color: #f44336; }
+    .mobile-toggle { display: none; }
     @media (max-width: 700px) {
       body { padding: 12px; }
       .form-container { margin-top: 32px; }
       .layout { flex-direction: column; }
-      .sidebar { width: 100%; border-right: none; padding-right: 0; border-bottom: 1px solid #333; padding-bottom: 12px; margin-bottom: 12px; }
+      .sidebar { width: 100%; border-right: none; padding-right: 0; }
+      .mobile-toggle { display: inline-block; }
+      .mobile-diagram .sidebar { display: none; }
+      .mobile-sidebar .main { display: none; }
       .toolbar { flex-wrap: wrap; }
       .toolbar-timer { margin-left: 0; }
       .heading-title { font-size: 16px; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -49,7 +49,7 @@
     .tree-repo { color: #777; font-size: 11px; padding: 2px 0 2px 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; justify-content: space-between; }
     .tree-remove { color: #555; cursor: pointer; font-size: 10px; padding: 0 4px; flex-shrink: 0; }
     .tree-remove:hover { color: #f44336; }
-    .tree-ref { color: #9e9e9e; font-size: 12px; padding: 3px 8px 3px 16px; border-radius: 4px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tree-ref { color: #9e9e9e; font-size: 12px; padding: 3px 8px 3px 16px; border-radius: 4px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: flex; align-items: center; justify-content: space-between; }
     .tree-ref:hover { color: #2196f3; background: #16213e; }
     .tree-ref-title { color: #555; font-size: 11px; }
     .form-tree-owner { font-size: 13px; margin-top: 8px; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -75,7 +75,6 @@
     .target-title { color: #777; font-size: 12px; font-weight: 400; }
     .target-remove { color: #666; cursor: pointer; font-size: 12px; padding: 2px 6px; }
     .target-remove:hover { color: #f44336; }
-    .main svg { max-width: 100%; overflow-x: auto; display: block; }
     @media (max-width: 700px) {
       body { padding: 12px; }
       .form-container { margin-top: 32px; }

--- a/justfile
+++ b/justfile
@@ -16,12 +16,12 @@ lint:
 ci: lint build bundle
 
 serve: bundle
-    python3 -m http.server 10000 -d dist
+    npx serve dist -l 10000
 
 restart: bundle
-    -pkill -f 'http.server 10000'
+    -pkill -f 'serve dist -l 10000'
     sleep 1
-    python3 -m http.server 10000 -d dist
+    npx serve dist -l 10000
 
 clean:
     rm -rf output/ dist/index.js

--- a/justfile
+++ b/justfile
@@ -18,5 +18,10 @@ ci: lint build bundle
 serve: bundle
     python3 -m http.server 10000 -d dist
 
+restart: bundle
+    -pkill -f 'http.server 10000'
+    sleep 1
+    python3 -m http.server 10000 -d dist
+
 clean:
     rm -rf output/ dist/index.js

--- a/src/FileIO.js
+++ b/src/FileIO.js
@@ -1,0 +1,26 @@
+export const downloadJsonImpl = (filename) => (content) => () => {
+  const blob = new Blob([content], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+};
+
+export const pickJsonFileImpl = (onSuccess) => (onCancel) => () => {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = ".json,application/json";
+  input.onchange = () => {
+    const file = input.files[0];
+    if (!file) { onCancel(); return; }
+    const reader = new FileReader();
+    reader.onload = () => onSuccess(reader.result)();
+    reader.onerror = () => onCancel();
+    reader.readAsText(file);
+  };
+  input.click();
+};

--- a/src/FileIO.purs
+++ b/src/FileIO.purs
@@ -1,0 +1,24 @@
+module FileIO
+  ( downloadJson
+  , pickJsonFile
+  ) where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Aff (Aff, makeAff, nonCanceler)
+
+foreign import downloadJsonImpl :: String -> String -> Effect Unit
+
+downloadJson :: String -> String -> Effect Unit
+downloadJson = downloadJsonImpl
+
+foreign import pickJsonFileImpl
+  :: (String -> Effect Unit) -> Effect Unit -> Effect Unit
+
+pickJsonFile :: Aff String
+pickJsonFile = makeAff \cb -> do
+  pickJsonFileImpl
+    (\s -> cb (pure s))
+    (cb (pure ""))
+  pure nonCanceler

--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -7,6 +7,8 @@ module GitHub
   , Step
   , WorkflowRun
   , Job
+  , fetchRuns
+  , fetchJobs
   , fetchPipeline
   , fetchOpenPRs
   ) where

--- a/src/GitHub.purs
+++ b/src/GitHub.purs
@@ -43,6 +43,7 @@ data Ref
   = PR Int
   | SHA String
   | Branch String
+  | Default
 
 type WorkflowRun =
   { id :: Number
@@ -257,6 +258,15 @@ resolveRef cfg = case cfg.ref of
       head :: { sha :: String } <- decodeField "head"
         r.json
       pure head.sha
+  Default -> do
+    result <- ghFetch cfg ""
+    case
+      result >>= \r ->
+        decodeField "default_branch" r.json
+      of
+      Left err -> pure (Left err)
+      Right (branch :: String) ->
+        resolveRef cfg { ref = Branch branch }
 
 fetchJobs
   :: Config

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -278,14 +278,14 @@ renderInputs state =
                   ]
               , HH.button
                   [ HE.onClick \_ -> Submit
-                  , HP.class_ (HH.ClassName "btn btn-sm")
+                  , HP.class_ (HH.ClassName "btn-small")
                   ]
-                  [ HH.text "Watch" ]
+                  [ HH.text "\x2713" ]
               , HH.button
                   [ HE.onClick \_ -> ToggleSidebarForm
                   , HP.class_ (HH.ClassName "btn-small")
                   ]
-                  [ HH.text "x" ]
+                  [ HH.text "\x2717" ]
               ]
           ]
       ]
@@ -317,14 +317,14 @@ renderInputs state =
                     ]
                 , HH.button
                     [ HE.onClick \_ -> ToggleTokenForm
-                    , HP.class_ (HH.ClassName "btn btn-sm")
+                    , HP.class_ (HH.ClassName "btn-small")
                     ]
-                    [ HH.text "OK" ]
+                    [ HH.text "\x2713" ]
                 , HH.button
                     [ HE.onClick \_ -> ToggleTokenForm
                     , HP.class_ (HH.ClassName "btn-small")
                     ]
-                    [ HH.text "x" ]
+                    [ HH.text "\x2717" ]
                 ]
             ]
         ]

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -338,14 +338,13 @@ renderSidebar
 renderSidebar state =
   HH.div
     [ HP.class_ (HH.ClassName "sidebar") ]
-    ( renderInputs state
-        <>
-          [ HH.div
-              [ HP.class_ (HH.ClassName "sidebar-title") ]
-              [ HH.text "Targets" ]
-          ]
+    ( [ HH.div
+          [ HP.class_ (HH.ClassName "sidebar-title") ]
+          [ HH.text "Targets" ]
+      ]
         <> bind (buildTree state.targets)
           renderOwnerNode
+        <> renderInputs state
         <>
           [ HH.button
               [ HE.onClick \_ -> ResetAll

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -416,18 +416,31 @@ renderRefItem
   :: forall w. TargetParts -> HH.HTML w Action
 renderRefItem parts =
   HH.div
-    [ HE.onClick \_ -> SelectTarget parts.target
-    , HP.class_ (HH.ClassName "tree-ref")
+    [ HP.class_ (HH.ClassName "tree-ref")
     , HP.title (refText <> titleText)
     ]
-    [ HH.text refText
-    , if parts.target.title == "" then HH.text ""
-      else
-        HH.span
-          [ HP.class_ (HH.ClassName "tree-ref-title") ]
-          [ HH.text
-              (" " <> truncate 44 parts.target.title)
-          ]
+    [ HH.span
+        [ HE.onClick \_ -> SelectTarget parts.target ]
+        ( [ HH.text refText ]
+            <>
+              if parts.target.title == "" then []
+              else
+                [ HH.span
+                    [ HP.class_
+                        (HH.ClassName "tree-ref-title")
+                    ]
+                    [ HH.text
+                        ( " " <> truncate 44
+                            parts.target.title
+                        )
+                    ]
+                ]
+        )
+    , HH.span
+        [ HE.onClick \_ -> RemoveTarget parts.target
+        , HP.class_ (HH.ClassName "tree-remove")
+        ]
+        [ HH.text "x" ]
     ]
   where
   refText =

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -179,6 +179,7 @@ render state = case state.config of
                           [ renderPipeline state.pipeline
                           ]
                   )
+              <> [ renderFooter ]
           )
       ]
 
@@ -464,6 +465,32 @@ renderToolbar state =
         ]
     ]
 
+renderFooter :: forall w i. HH.HTML w i
+renderFooter =
+  HH.div
+    [ HP.class_ (HH.ClassName "repo-links") ]
+    [ HH.a
+        [ HP.href
+            "https://github.com/paolino/gha-live"
+        , HP.target "_blank"
+        ]
+        [ HH.text "GitHub" ]
+    , HH.text " · "
+    , HH.a
+        [ HP.href
+            "https://github.com/paolino/gha-live/issues"
+        , HP.target "_blank"
+        ]
+        [ HH.text "Issues" ]
+    , HH.text " · "
+    , HH.img
+        [ HP.src
+            "https://img.shields.io/github/stars/paolino/gha-live?style=flat&color=333"
+        , HP.alt "GitHub stars"
+        , HP.class_ (HH.ClassName "badge")
+        ]
+    ]
+
 renderForm
   :: forall w. State -> HH.HTML w Action
 renderForm state =
@@ -573,29 +600,7 @@ renderForm state =
                   ]
               ]
           ]
-      , HH.div
-          [ HP.class_ (HH.ClassName "repo-links") ]
-          [ HH.a
-              [ HP.href
-                  "https://github.com/paolino/gha-live"
-              , HP.target "_blank"
-              ]
-              [ HH.text "GitHub" ]
-          , HH.text " · "
-          , HH.a
-              [ HP.href
-                  "https://github.com/paolino/gha-live/issues"
-              , HP.target "_blank"
-              ]
-              [ HH.text "Issues" ]
-          , HH.text " · "
-          , HH.img
-              [ HP.src
-                  "https://img.shields.io/github/stars/paolino/gha-live?style=flat&color=333"
-              , HP.alt "GitHub stars"
-              , HP.class_ (HH.ClassName "badge")
-              ]
-          ]
+      , renderFooter
       ]
         <> renderTargets state.targets
     )

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -629,11 +629,16 @@ renderForm state =
                   ]
               , HH.li_
                   [ HH.text
-                      "Open PRs are discovered automatically"
+                      "Open PRs are discovered automatically — hide any with "
+                  , HH.code_ [ HH.text "x" ]
                   ]
               , HH.li_
                   [ HH.text
                       "Targets are saved in your browser"
+                  ]
+              , HH.li_
+                  [ HH.text
+                      "Export / import your settings, or reset everything"
                   ]
               , HH.li_
                   [ HH.text

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -631,6 +631,8 @@ renderForm state =
                   [ HH.text
                       "Open PRs are discovered automatically — hide any with "
                   , HH.code_ [ HH.text "x" ]
+                  , HH.text
+                      ", re-add the URL to unhide"
                   ]
               , HH.li_
                   [ HH.text

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -291,7 +291,7 @@ renderInputs state =
           [ HE.onClick \_ -> ToggleSidebarForm
           , HP.class_ (HH.ClassName "btn-add")
           ]
-          [ HH.text "+" ]
+          [ HH.text "\x1F517" ]
       ]
   )
     <>
@@ -350,7 +350,7 @@ renderSidebar state =
               [ HE.onClick \_ -> ResetAll
               , HP.class_ (HH.ClassName "btn-reset")
               ]
-              [ HH.text "Reset" ]
+              [ HH.text "\x1F5D1" ]
           ]
     )
 

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -500,7 +500,7 @@ renderForm state =
       , HH.p
           [ HP.class_ (HH.ClassName "muted") ]
           [ HH.text
-              "Watch GitHub Actions pipelines in real time."
+              "Watch GitHub Actions pipelines in real time. Runs entirely in your browser — no server, your token never leaves your machine."
           ]
       , HH.div
           [ HP.class_ (HH.ClassName "form") ]
@@ -597,6 +597,21 @@ renderForm state =
               , HH.li_
                   [ HH.text
                       "Click any job to open it on GitHub"
+                  ]
+              ]
+          , HH.h3_ [ HH.text "Privacy" ]
+          , HH.ul_
+              [ HH.li_
+                  [ HH.text
+                      "No backend — the app is a static page that runs in your browser"
+                  ]
+              , HH.li_
+                  [ HH.text
+                      "Your GitHub token is stored in localStorage and sent only to the GitHub API"
+                  ]
+              , HH.li_
+                  [ HH.text
+                      "Nothing is logged or transmitted to any third party"
                   ]
               ]
           ]

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -924,19 +924,17 @@ doFetch cfg = do
       H.modify_ _
         { error = Just err, loading = false }
     Right runs -> do
-      -- Show runs immediately with empty jobs
       st <- H.get
       let merged = foldl (flip addTarget) st.targets prTargets
       H.modify_ _
-        { pipeline = buildPipeline runs []
-        , error = Nothing
+        { error = Nothing
         , loading = true
         , targets = merged
         , headingRepo = cfg.owner <> "/" <> cfg.repo
         , headingTitle = title
         }
       liftEffect $ saveTargets merged
-      -- Fetch jobs incrementally per run
+      -- Fetch jobs incrementally, updating each run in place
       allJobs <- fetchJobsIncremental cfg runs
       st' <- H.get
       let

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -809,7 +809,14 @@ handleAction = case _ of
           do
             let
               newTargets = addTarget target st.targets
-              newRemoved = filter (_ /= st.formUrl)
+              repoPrefix = "https://github.com/"
+                <> owner
+                <> "/"
+                <> repo
+              matchesRepo u =
+                indexOf (Pattern repoPrefix) u == Just 0
+              newRemoved = filter
+                (not <<< matchesRepo)
                 st.removedUrls
             H.modify_ _
               { targets = newTargets

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -933,7 +933,7 @@ doFetch cfg = do
         , headingTitle = title
         }
       liftEffect $ saveTargets merged
-      -- Fetch jobs incrementally, updating each run in place
+      -- Fetch jobs incrementally, replacing per run
       allJobs <- fetchJobsIncremental cfg runs
       st' <- H.get
       let
@@ -978,14 +978,12 @@ fetchJobsIncremental cfg runs = go runs []
       case result of
         Left _ -> go rest acc
         Right { jobs, rateLimit } -> do
-          let newAcc = acc <> jobs
           H.modify_ \st -> st
-            { pipeline = buildPipeline runs newAcc
-            , rateLimit = case rateLimit of
+            { rateLimit = case rateLimit of
                 Just rl -> Just rl
                 Nothing -> st.rateLimit
             }
-          go rest newAcc
+          go rest (acc <> jobs)
 
 ticker :: Number -> HS.Emitter Action
 ticker ms = HS.makeEmitter \emit -> do

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -442,7 +442,7 @@ renderRefItem parts =
                         (HH.ClassName "tree-ref-title")
                     ]
                     [ HH.text
-                        ( " " <> truncate 44
+                        ( " " <> truncate 36
                             parts.target.title
                         )
                     ]

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -1041,6 +1041,7 @@ doFetch cfg = do
   let
     refCalls = case cfg.ref of
       SHA _ -> 0
+      Default -> 2
       _ -> 1
     prTargets = case prsResult of
       Left _ -> []
@@ -1072,6 +1073,7 @@ doFetch cfg = do
             (map (\t -> " " <> t) prTitle)
       Branch b -> b
       SHA s -> take 7 s
+      Default -> "(default)"
   case runsResult of
     Left err ->
       H.modify_ _
@@ -1161,6 +1163,7 @@ refLabel = case _ of
   PR n -> " #" <> show n
   SHA s -> " @" <> take 7 s
   Branch b -> " (" <> b <> ")"
+  Default -> ""
 
 addTarget :: Target -> Array Target -> Array Target
 addTarget t ts =
@@ -1214,6 +1217,7 @@ loadConfig s = do
         "pr" -> PR <$> Int.fromString obj.refVal
         "sha" -> Just (SHA obj.refVal)
         "branch" -> Just (Branch obj.refVal)
+        "default" -> Just Default
         _ -> Nothing
       Just
         { owner: obj.owner
@@ -1266,6 +1270,7 @@ saveConfig cfg = do
       PR n -> { tag: "pr", val: show n }
       SHA s -> { tag: "sha", val: s }
       Branch b -> { tag: "branch", val: b }
+      Default -> { tag: "default", val: "" }
     json = encodeJson
       { owner: cfg.owner
       , repo: cfg.repo
@@ -1344,14 +1349,14 @@ parseRefFromSegs segs =
     Just "pull", Just n ->
       case Int.fromString n of
         Just i -> PR i
-        Nothing -> Branch "main"
+        Nothing -> Default
     Just "issues", Just n ->
       case Int.fromString n of
         Just i -> PR i
-        Nothing -> Branch "main"
+        Nothing -> Default
     Just "tree", Just b -> Branch b
     Just "commit", Just s -> SHA s
-    _, _ -> Branch "main"
+    _, _ -> Default
 
 stripPrefix' :: String -> String -> Maybe String
 stripPrefix' prefix s =

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -780,8 +780,15 @@ handleAction = case _ of
           do
             let
               newTargets = addTarget target st.targets
-            H.modify_ _ { targets = newTargets }
-            liftEffect $ saveTargets newTargets
+              newRemoved = filter (_ /= st.formUrl)
+                st.removedUrls
+            H.modify_ _
+              { targets = newTargets
+              , removedUrls = newRemoved
+              }
+            liftEffect do
+              saveTargets newTargets
+              saveRemoved newRemoved
             startWatching cfg
   SelectTarget target -> do
     H.modify_ _ { formUrl = target.url }

--- a/src/Pipeline.purs
+++ b/src/Pipeline.purs
@@ -1,6 +1,7 @@
 -- | Pipeline model — build the DAG of workflows and jobs from API data.
 module Pipeline
   ( Status(..)
+  , StepView
   , JobView
   , RunView
   , buildPipeline
@@ -10,7 +11,7 @@ import Prelude
 
 import Data.Array (filter)
 import Data.Maybe (Maybe(..))
-import GitHub (WorkflowRun, Job)
+import GitHub (Step, WorkflowRun, Job)
 
 data Status
   = Pending
@@ -21,11 +22,19 @@ data Status
   | Cancelled
   | Skipped
 
+type StepView =
+  { name :: String
+  , status :: Status
+  }
+
 type JobView =
   { id :: Number
   , name :: String
   , status :: Status
   , htmlUrl :: String
+  , startedAt :: Maybe String
+  , completedAt :: Maybe String
+  , steps :: Array StepView
   }
 
 type RunView =
@@ -70,4 +79,13 @@ buildPipeline runs jobs =
     , name: job.name
     , status: toStatus job.status job.conclusion
     , htmlUrl: job.htmlUrl
+    , startedAt: job.startedAt
+    , completedAt: job.completedAt
+    , steps: map toStepView job.steps
+    }
+
+  toStepView :: Step -> StepView
+  toStepView step =
+    { name: step.name
+    , status: toStatus step.status step.conclusion
     }

--- a/src/Pipeline.purs
+++ b/src/Pipeline.purs
@@ -9,7 +9,7 @@ module Pipeline
 
 import Prelude
 
-import Data.Array (filter)
+import Data.Array (filter, sortBy)
 import Data.Maybe (Maybe(..))
 import GitHub (Step, WorkflowRun, Job)
 
@@ -67,7 +67,8 @@ buildPipeline runs jobs =
     { id: run.id
     , name: run.name
     , status: toStatus run.status run.conclusion
-    , jobs: map toJobView (jobsForRun run.id)
+    , jobs: sortBy (\a b -> compare a.name b.name)
+        $ map toJobView (jobsForRun run.id)
     }
 
   jobsForRun :: Number -> Array Job

--- a/src/Pipeline.purs
+++ b/src/Pipeline.purs
@@ -60,7 +60,8 @@ toStatus status conclusion = case status, conclusion of
 buildPipeline
   :: Array WorkflowRun -> Array Job -> Array RunView
 buildPipeline runs jobs =
-  map buildRun runs
+  sortBy (\a b -> compare a.name b.name)
+    $ map buildRun runs
   where
   buildRun :: WorkflowRun -> RunView
   buildRun run =

--- a/src/View.purs
+++ b/src/View.purs
@@ -46,7 +46,7 @@ labelH :: Number
 labelH = 20.0
 
 charW :: Number
-charW = 7.0
+charW = 8.0
 
 hPad :: Number
 hPad = 16.0
@@ -183,7 +183,7 @@ renderJob xOff colW rowIdx job =
           [ SA.x (xBox + boxW / 2.0)
           , SA.y (yBox + jobH / 2.0 + 4.0)
           , SA.fill (Named "#ffffff")
-          , SA.fontSize (FontSizeLength (Px 11.0))
+          , SA.fontSize (FontSizeLength (Px 13.0))
           , SA.textAnchor AnchorMiddle
           , SA.class_ (ClassName "job-label")
           ]

--- a/src/View.purs
+++ b/src/View.purs
@@ -228,9 +228,10 @@ jobTooltip job =
     steps = map stepLine job.steps
     lines = [ job.name ]
       <> (if duration == "" then [] else [ duration ])
-      <> ( if Array.null steps then []
-           else [ "---" ] <> steps
-         )
+      <>
+        ( if Array.null steps then []
+          else [ "---" ] <> steps
+        )
   in
     intercalate "\n" lines
 

--- a/src/View.purs
+++ b/src/View.purs
@@ -133,7 +133,7 @@ renderRun runs colIdx run =
             [ SA.x (xOff + w / 2.0)
             , SA.y (padding + labelH)
             , SA.fill (Named "#e0e0e0")
-            , SA.fontSize (FontSizeLength (Px 12.0))
+            , SA.fontSize (FontSizeLength (Px 14.0))
             , SA.textAnchor AnchorMiddle
             , SA.class_ (ClassName "run-label")
             ]


### PR DESCRIPTION
## Summary

- On mobile (< 700px), sidebar and diagram are separate pages instead of stacked
- Toolbar shows a Targets/Diagram toggle button (hidden on desktop)
- Selecting a target auto-switches to the diagram page
- SVG pipeline scrolls horizontally on small screens