### PR TITLE
feat: mobile-friendly UI, target management, and API improvements

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -75,11 +75,15 @@
     .target-title { color: #777; font-size: 12px; font-weight: 400; }
     .target-remove { color: #666; cursor: pointer; font-size: 12px; padding: 2px 6px; }
     .target-remove:hover { color: #f44336; }
+    .mobile-toggle { display: none; }
     @media (max-width: 700px) {
       body { padding: 12px; }
       .form-container { margin-top: 32px; }
       .layout { flex-direction: column; }
-      .sidebar { width: 100%; border-right: none; padding-right: 0; border-bottom: 1px solid #333; padding-bottom: 12px; margin-bottom: 12px; }
+      .sidebar { width: 100%; border-right: none; padding-right: 0; }
+      .mobile-toggle { display: inline-block; }
+      .mobile-diagram .sidebar { display: none; }
+      .mobile-sidebar .main { display: none; }
       .toolbar { flex-wrap: wrap; }
       .toolbar-timer { margin-left: 0; }
       .heading-title { font-size: 16px; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -88,15 +88,12 @@
       .toolbar-timer { margin-left: 0; }
       .heading-title { font-size: 16px; }
       .main { overflow-x: auto; }
-      .tree-owner { font-size: 16px; padding: 12px 0 4px; }
-      .tree-repo { font-size: 15px; padding: 8px 0 8px 8px; min-height: 44px; box-sizing: border-box; }
-      .tree-ref { font-size: 16px; padding: 10px 8px 10px 16px; min-height: 44px; box-sizing: border-box; }
-      .tree-ref-title { font-size: 13px; }
-      .tree-remove { font-size: 16px; padding: 4px 12px; min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; }
-      .sidebar-title { font-size: 14px; }
-      .btn-add { padding: 12px; font-size: 18px; }
-      .btn-reset { padding: 10px; font-size: 14px; }
-      .btn-back { padding: 10px 18px; font-size: 15px; }
+      .tree-owner { font-size: 14px; padding: 8px 0 2px; }
+      .tree-repo { font-size: 13px; padding: 4px 0 4px 8px; }
+      .tree-ref { font-size: 14px; padding: 6px 8px 6px 16px; }
+      .tree-ref-title { font-size: 12px; }
+      .tree-remove { font-size: 12px; padding: 2px 8px; }
+      .sidebar-title { font-size: 13px; }
     }
   </style>
 </head>

--- a/dist/index.html
+++ b/dist/index.html
@@ -88,12 +88,15 @@
       .toolbar-timer { margin-left: 0; }
       .heading-title { font-size: 16px; }
       .main { overflow-x: auto; }
-      .tree-owner { font-size: 16px; padding: 10px 0 4px; }
-      .tree-repo { font-size: 14px; padding: 4px 0 4px 8px; }
-      .tree-ref { font-size: 15px; padding: 6px 8px 6px 16px; }
+      .tree-owner { font-size: 16px; padding: 12px 0 4px; }
+      .tree-repo { font-size: 15px; padding: 8px 0 8px 8px; min-height: 44px; box-sizing: border-box; }
+      .tree-ref { font-size: 16px; padding: 10px 8px 10px 16px; min-height: 44px; box-sizing: border-box; }
       .tree-ref-title { font-size: 13px; }
-      .tree-remove { font-size: 14px; padding: 2px 8px; }
+      .tree-remove { font-size: 16px; padding: 4px 12px; min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center; }
       .sidebar-title { font-size: 14px; }
+      .btn-add { padding: 12px; font-size: 18px; }
+      .btn-reset { padding: 10px; font-size: 14px; }
+      .btn-back { padding: 10px 18px; font-size: 15px; }
     }
   </style>
 </head>

--- a/dist/index.html
+++ b/dist/index.html
@@ -76,7 +76,7 @@
     .target-remove { color: #666; cursor: pointer; font-size: 12px; padding: 2px 6px; }
     .target-remove:hover { color: #f44336; }
     .mobile-toggle { display: none; }
-    @media (max-width: 700px) {
+    @media (max-width: 900px) {
       body { padding: 12px; }
       .form-container { margin-top: 32px; }
       .layout { flex-direction: column; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -88,6 +88,12 @@
       .toolbar-timer { margin-left: 0; }
       .heading-title { font-size: 16px; }
       .main { overflow-x: auto; }
+      .tree-owner { font-size: 16px; padding: 10px 0 4px; }
+      .tree-repo { font-size: 14px; padding: 4px 0 4px 8px; }
+      .tree-ref { font-size: 15px; padding: 6px 8px 6px 16px; }
+      .tree-ref-title { font-size: 13px; }
+      .tree-remove { font-size: 14px; padding: 2px 8px; }
+      .sidebar-title { font-size: 14px; }
     }
   </style>
 </head>

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -150,12 +150,11 @@ render state = case state.config of
     HH.div_
       [ renderToolbar state
       , HH.div
-          [ HP.class_
-              ( HH.ClassName
-                  ( "layout mobile-"
-                      <> state.mobilePage
-                  )
-              )
+          [ HP.classes
+              [ HH.ClassName "layout"
+              , HH.ClassName
+                  ("mobile-" <> state.mobilePage)
+              ]
           ]
           [ renderSidebar state
           , HH.div

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -480,15 +480,17 @@ renderToolbar state =
     [ HP.class_ (HH.ClassName "toolbar") ]
     [ HH.button
         [ HE.onClick \_ -> SetMobilePage
-            if state.mobilePage == "diagram" then
-              "sidebar"
-            else "diagram"
+            ( if state.mobilePage == "diagram" then
+                "sidebar"
+              else "diagram"
+            )
         , HP.class_ (HH.ClassName "btn-back mobile-toggle")
         ]
         [ HH.text
-            if state.mobilePage == "sidebar" then
-              "Diagram"
-            else "Targets"
+            ( if state.mobilePage == "sidebar" then
+                "Diagram"
+              else "Targets"
+            )
         ]
     , HH.button
         [ HE.onClick \_ -> Refresh
@@ -496,8 +498,9 @@ renderToolbar state =
         , HP.disabled state.loading
         ]
         [ HH.text
-            if state.loading then "Refreshing..."
-            else "Refresh"
+            ( if state.loading then "Refreshing..."
+              else "Refresh"
+            )
         ]
     , HH.span
         [ HP.class_ (HH.ClassName "toolbar-timer") ]


### PR DESCRIPTION
## Summary

- Mobile page switching: sidebar and diagram on separate screens with toggle button
- Responsive layout with larger touch targets on mobile (< 900px breakpoint)
- Per-PR hide/unhide with persistent blocklist in localStorage
- Export/import settings, help button showing splash docs
- Incremental pipeline rendering without blanking on refresh
- Fetch default branch from API instead of assuming main
- Proper HTTP error messages from GitHub API
- SVG tooltips, alphabetical sorting, icon buttons, privacy docs